### PR TITLE
fix(case-studies): mobile responsive on autoapply-ai + tailor-resume (#44)

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1127,10 +1127,35 @@ button { font-family: inherit; cursor: pointer; }
 .cs-lesson.failed h4 { color: var(--accent-warm); }
 .cs-lesson p { color: var(--fg-soft); font-size: 0.86rem; }
 
-@media (max-width: 700px) {
+/* Inline <code> in case-study prose can hold long shell snippets like
+   "tailor-resume --artifact PATH:FORMAT --jd JD_PATH" (42 chars). On
+   narrow viewports those overflow the column and trigger horizontal
+   scroll. overflow-wrap: anywhere lets the browser break inside the
+   code text only when it would otherwise overflow — desktop is
+   unaffected. */
+.cs-section code, .cs-hero code, .cs-section p code {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+@media (max-width: 780px) {
   .cs-nav { padding: 0.875rem 1rem; }
   .cs-hero { padding: 2.5rem 0 2rem; }
+  .cs-hero__summary { font-size: 0.97rem; line-height: 1.7; }
+  .cs-proof-strip { gap: 0.4rem 0.55rem; }
+  .cs-proof-strip span { font-size: 0.72rem; padding: 0.25rem 0.6rem; }
+  .cs-section { padding: 1.75rem 0; }
+  .cs-section p { font-size: 0.95rem; line-height: 1.7; }
   .cs-lessons { grid-template-columns: 1fr; }
+}
+
+/* Very narrow phones: hide the right-side site-name in the back nav
+   so the back-link has the row to itself. The site-name reads as
+   chrome, not content — no information lost when it's gone. */
+@media (max-width: 480px) {
+  .cs-nav__name { display: none; }
+  .cs-nav { justify-content: flex-start; }
+  .cs-hero h1 { font-size: 1.65rem; line-height: 1.2; }
 }
 
 /* inline code in system-desc */


### PR DESCRIPTION
## Summary

The case-study subpages (autoapply-ai.html, tailor-resume.html) had a thin mobile breakpoint that only adjusted nav + hero padding. Several layout issues showed up at \`<=780px\` / 320 / 375 / 412 px:

- \`.cs-section\` padding stayed at 2.5rem (too much vertical space on phones, pushed CTAs below the fold)
- \`.cs-proof-strip span\` pills kept their full size + padding, looking cramped against narrow viewports
- \`.cs-hero__summary\` kept its 1.05rem font, eating screen real estate
- \`.cs-nav\` had the back-link AND the right-side site-name colliding at ~360px and below
- Inline \`<code>\` with long shell strings (e.g. \`tailor-resume --artifact PATH:FORMAT --jd JD_PATH\` — 42 chars) overflowed the text column at 320px, forcing **horizontal scroll on the whole page**

## What changed

- Bump the cs-* mobile breakpoint from 700px → 780px to match the rest of the site
- Shrink \`.cs-hero__summary\`, \`.cs-section p\`, \`.cs-proof-strip span\` fonts and tighten paddings on mobile
- Add \`overflow-wrap: anywhere\` on \`.cs-section\` / \`.cs-hero\` \`<code>\` so long shell strings break-wrap instead of pushing horizontal scroll
- New 480px breakpoint hides \`.cs-nav__name\` (the right-side filename — pure chrome, no info loss) so the back-link gets the row to itself; also fine-tunes \`.cs-hero h1\` size at the tightest widths

CSS-only change — no HTML, no JS. \`styles.css\` +26 / -1 lines.

## Closes

#44

## Test plan

- [x] Visual verification at 320 / 375 / 412 / 780 px on both subpages
- [x] No horizontal scroll on either page at any width
- [x] 55/55 self-test assertions pass (\`python scripts/test-portfolio.py --self-test\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)