### PR TITLE
fix(hero): exempt .hero-visual from data-reveal so img stays LCP-eligible (#77)

### DIFF
--- a/index.html
+++ b/index.html
@@ -141,7 +141,7 @@
           </div>
         </div>
 
-        <aside class="hero-visual" data-reveal>
+        <aside class="hero-visual">
 
           <div class="profile-frame hero-photo-stack">
             <img src="static/originals/headshot-fullbody.jpg"

--- a/scripts/test-portfolio.py
+++ b/scripts/test-portfolio.py
@@ -344,6 +344,28 @@ def test_hero_uses_local_photo_not_external_cdn(html: str) -> None:
         )
 
 
+def test_hero_aside_no_data_reveal(html: str) -> None:
+    """Issue #77: the <aside class="hero-visual"> MUST NOT carry a
+    data-reveal attribute. data-reveal sets opacity:0 + 0.55s fade
+    via styles.css [data-reveal] rules — Chrome's LCP algorithm
+    excludes opacity:0 elements as candidates, so wrapping the hero
+    img in data-reveal silently disqualifies it from being the LCP
+    element. The post-merge Lighthouse audit (2026-05-01T16:05Z)
+    measured Mobile LCP at 2854ms because of this exact bug.
+
+    Removing this regression guard (or re-adding data-reveal to the
+    hero aside) would re-introduce the LCP regression with no other
+    CI signal."""
+    m = re.search(r'<aside\s+class="hero-visual"[^>]*>', html)
+    assert m, "hero-visual <aside> not found in index.html"
+    aside_open = m.group(0)
+    assert "data-reveal" not in aside_open, (
+        f"hero-visual <aside> carries data-reveal — this disqualifies the "
+        f"hero img from being Chrome's LCP candidate (opacity:0 fence). "
+        f"See PR #81 / issue #77. Aside tag: {aside_open}"
+    )
+
+
 def test_no_inline_style_attribute_on_strips(inline_styles: list) -> None:
     assert not inline_styles, (
         f"Found inline style= attributes inside impact strips: {inline_styles}; "
@@ -997,6 +1019,7 @@ TESTS = [
     test_no_scrapped_exponenthr_outcomes,
     test_no_scrapped_exponenthr_outcomes_in_rendered_text,
     test_hero_uses_local_photo_not_external_cdn,
+    test_hero_aside_no_data_reveal,
     test_no_inline_style_attribute_on_strips,
     test_jetbrains_mono_loaded,
     test_css_uses_tabular_nums,


### PR DESCRIPTION
## Summary

Closes #77. Drops the \`data-reveal\` attribute from the hero \`<aside>\` so its image isn't disqualified from being Chrome's LCP candidate by the \`opacity: 0\` initial state.

## Diagnosis (from PR #45 audit comment)

Post-merge Lighthouse audit fired 2026-05-01T16:05Z:

| | Performance | LCP | Verdict |
|---|---|---|---|
| Mobile (Slow 4G) | 94/100 | **2854ms** | LCP **FAIL** (target <1800ms) |
| Desktop | 99/100 | 772ms | PASS |

Root cause confirmed by audit: \`[data-reveal]\` applies \`opacity: 0\` + a 0.55s fade transition. The hero \`<aside class=\"hero-visual\" data-reveal>\` wrapped the LCP image, so Chrome refused to register the headshot as an LCP candidate until the IntersectionObserver fired and the fade completed. The preload + \`fetchpriority=high\` + intrinsic dimensions were all correct; the opacity fence negated them.

## Fix

\`\`\`diff
- <aside class=\"hero-visual\" data-reveal>
+ <aside class=\"hero-visual\">
\`\`\`

Below-fold blocks keep their reveal animation untouched.

## Predicted impact

Mobile LCP 2854ms → ~1200-1500ms on Slow 4G. The image is already preloaded; the only blocker was the opacity fence.

## Test plan

- [x] 55/55 self-test assertions pass (\`python scripts/test-portfolio.py --self-test\`)
- [x] Visual: hero pane still appears correctly on page load (was already visible immediately because the fade is fast; no UX regression)
- [ ] Re-run the Lighthouse routine after merge: \`/schedule run\` on \`trig_01RDTgMWPyus3XwfMjLqTDSM\` — should report mobile LCP < 1800ms

🤖 Generated with [Claude Code](https://claude.com/claude-code)