### PR TITLE
feat(hover-preview): smaller card + scroll-aware + Substack live feed

### DIFF
--- a/.github/workflows/substack-snapshot.yml
+++ b/.github/workflows/substack-snapshot.yml
@@ -1,0 +1,54 @@
+name: Substack snapshot
+
+# Periodically fetch the latest posts from the Substack RSS feed and
+# commit a same-origin JSON snapshot. The hover-preview popup reads
+# this file directly (no client-side CORS, no third-party tracking).
+#
+# See scripts/snap-substack-feed.py for the parser + output contract.
+
+on:
+  schedule:
+    # Every 4 hours. Substack publication is weekly cadence; 4h is
+    # plenty fresh, keeps commit log tidy. Adjust if you ever post
+    # multiple times per day and want sub-hour freshness.
+    - cron: '17 */4 * * *'
+  workflow_dispatch: {}  # manual fire from the Actions tab
+
+permissions:
+  contents: write  # commit + push the JSON snapshot
+
+concurrency:
+  group: substack-snapshot
+  cancel-in-progress: false
+
+jobs:
+  snapshot:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Fetch + parse Substack feed
+        run: python scripts/snap-substack-feed.py
+
+      - name: Commit snapshot if changed
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- static/substack-latest.json; then
+            echo "no change to substack-latest.json — skipping commit"
+            exit 0
+          fi
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add static/substack-latest.json
+          # `[skip ci]` so the deploy workflow doesn't re-fire on
+          # this commit (deploy.yml already runs on push to main and
+          # we don't want a recursive build loop). Pages auto-deploys
+          # on push regardless.
+          git commit -m "chore(substack): refresh latest-posts snapshot [skip ci]"
+          git push

--- a/app.js
+++ b/app.js
@@ -142,7 +142,9 @@
     var OPEN_DELAY  = 80;
     var CLOSE_GRACE = 250;
 
-    var card, thumb, titleEl, captionEl;
+    // Closure-scoped so renderStatic() + renderSubstack() can swap them
+    // in/out of the card's `inner` container as the render mode changes.
+    var card, inner, thumb, textWrap, titleEl, captionEl;
     var lastTrigger = null;
     var openTimer = null;
     var closeTimer = null;
@@ -154,7 +156,7 @@
       card.id = 'hover-preview-card';
       card.setAttribute('popover', 'manual');
 
-      var inner = document.createElement('div');
+      inner = document.createElement('div');
       inner.className = 'hover-preview-card';
 
       thumb = document.createElement('img');
@@ -166,7 +168,7 @@
       thumb.setAttribute('height', '320');
       inner.appendChild(thumb);
 
-      var textWrap = document.createElement('div');
+      textWrap = document.createElement('div');
       textWrap.className = 'hover-preview-text';
       titleEl = document.createElement('p');
       titleEl.className = 'hover-preview-title';

--- a/app.js
+++ b/app.js
@@ -246,6 +246,29 @@
       return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
     }
 
+    function selectPostsForTrigger(allPosts, triggerHref) {
+      // Per-trigger pin: if the trigger's href is a specific post URL
+      // (not the publication root), find that post in the JSON and
+      // surface it FIRST, followed by the 2 next most recent posts
+      // (excluding the pinned one). For root-URL triggers — or any
+      // href that doesn't match a post — fall back to the top-3
+      // most-recent default.
+      if (!triggerHref) return allPosts.slice(0, 3);
+      // Normalize: ignore trailing slash + url fragment for match
+      var norm = function (u) { return (u || '').split('#')[0].replace(/\/$/, ''); };
+      var target = norm(triggerHref);
+      var pinned = null;
+      for (var i = 0; i < allPosts.length; i++) {
+        if (norm(allPosts[i].url) === target) {
+          pinned = allPosts[i];
+          break;
+        }
+      }
+      if (!pinned) return allPosts.slice(0, 3);
+      var others = allPosts.filter(function (p) { return p !== pinned; });
+      return [pinned].concat(others.slice(0, 2));
+    }
+
     function buildFeedDom(trigger, data) {
       var frag = document.createDocumentFragment();
       var header = document.createElement('p');
@@ -254,18 +277,19 @@
         trigger.getAttribute('data-hover-title') || 'Latest posts';
       frag.appendChild(header);
 
-      var posts = (data && data.posts) || [];
-      if (!posts.length) {
+      var allPosts = (data && data.posts) || [];
+      if (!allPosts.length) {
         var empty = document.createElement('p');
         empty.className = 'hp-feed-empty';
         empty.textContent = (data === null) ? 'Could not load latest posts.' : 'No posts yet.';
         frag.appendChild(empty);
         return frag;
       }
+      var posts = selectPostsForTrigger(allPosts, trigger.getAttribute('href'));
 
       var list = document.createElement('ul');
       list.className = 'hp-feed-list';
-      posts.slice(0, 3).forEach(function (post) {
+      posts.forEach(function (post) {
         var item = document.createElement('a');
         item.className = 'hp-feed-item';
         item.href = post.url;

--- a/app.js
+++ b/app.js
@@ -191,21 +191,149 @@
       var top = rt.bottom + pad;
       var left = rt.left + rt.width / 2 - rc.width / 2;
       var maxLeft = window.innerWidth - rc.width - pad;
+      var maxTop  = window.innerHeight - rc.height - pad;
       if (left < pad) left = pad;
       if (left > maxLeft) left = maxLeft;
       if (top + rc.height > window.innerHeight - pad) {
+        // Try flipping above the trigger if there's room there.
         top = rt.top - rc.height - pad;
       }
+      // Final clamp: keep popover inside the viewport even when the
+      // trigger has scrolled partly off-screen (the scroll listener
+      // re-calls this on every frame; without clamping, the popover
+      // drifts off the visible area when the trigger does).
+      if (top < pad) top = pad;
+      if (top > maxTop) top = maxTop;
       card.style.top  = top  + 'px';
       card.style.left = left + 'px';
     }
 
-    function open(trigger) {
-      ensureCard();
+    function clearChildren(el) {
+      // Safe DOM clear without using innerHTML (avoids XSS-by-mistake
+      // surface and pleases the repo's security lint hook).
+      while (el.firstChild) el.removeChild(el.firstChild);
+    }
+
+    // ---- Render-mode branch (substack-live follow-up) ----
+    // Static mode (default): reuses the cached thumb + title + caption
+    // children. Substack-feed mode: replaces inner with the live-feed
+    // list rendered from /static/substack-latest.json (snapshot built
+    // hourly by .github/workflows/substack-snapshot.yml). Cached per
+    // feed URL so the fetch only happens once per page load.
+    var renderMode = null;  // 'static' | 'substack-feed'
+    var feedCache = Object.create(null);
+    var feedFetching = Object.create(null);
+
+    function renderStatic(trigger) {
+      if (renderMode !== 'static') {
+        clearChildren(inner);
+        inner.appendChild(thumb);
+        inner.appendChild(textWrap);
+        renderMode = 'static';
+      }
       var src = trigger.getAttribute('data-hover-preview');
       if (thumb.getAttribute('src') !== src) thumb.setAttribute('src', src);
       titleEl.textContent   = trigger.getAttribute('data-hover-title')   || '';
       captionEl.textContent = trigger.getAttribute('data-hover-caption') || '';
+    }
+
+    function formatFeedDate(iso) {
+      if (!iso) return '';
+      var d = new Date(iso);
+      if (isNaN(d.getTime())) return iso;
+      return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+    }
+
+    function buildFeedDom(trigger, data) {
+      var frag = document.createDocumentFragment();
+      var header = document.createElement('p');
+      header.className = 'hp-feed-header';
+      header.textContent = (data && data.publication) ||
+        trigger.getAttribute('data-hover-title') || 'Latest posts';
+      frag.appendChild(header);
+
+      var posts = (data && data.posts) || [];
+      if (!posts.length) {
+        var empty = document.createElement('p');
+        empty.className = 'hp-feed-empty';
+        empty.textContent = (data === null) ? 'Could not load latest posts.' : 'No posts yet.';
+        frag.appendChild(empty);
+        return frag;
+      }
+
+      var list = document.createElement('ul');
+      list.className = 'hp-feed-list';
+      posts.slice(0, 3).forEach(function (post) {
+        var item = document.createElement('a');
+        item.className = 'hp-feed-item';
+        item.href = post.url;
+        item.target = '_blank';
+        item.rel = 'noreferrer';
+
+        var title = document.createElement('p');
+        title.className = 'hp-feed-title';
+        title.textContent = post.title;
+        item.appendChild(title);
+
+        var meta = document.createElement('p');
+        meta.className = 'hp-feed-meta';
+        meta.textContent = formatFeedDate(post.published_at);
+        item.appendChild(meta);
+
+        var li = document.createElement('li');
+        li.appendChild(item);
+        list.appendChild(li);
+      });
+      frag.appendChild(list);
+      return frag;
+    }
+
+    function renderSubstack(trigger) {
+      clearChildren(inner);
+      renderMode = 'substack-feed';
+      var feedUrl = trigger.getAttribute('data-hover-feed') || '/static/substack-latest.json';
+
+      if (feedCache[feedUrl] !== undefined) {
+        inner.appendChild(buildFeedDom(trigger, feedCache[feedUrl]));
+        return;
+      }
+
+      // Loading placeholder shown while the JSON is in-flight.
+      var loading = document.createElement('p');
+      loading.className = 'hp-feed-empty';
+      loading.textContent = 'Loading latest posts...';
+      inner.appendChild(loading);
+
+      if (!feedFetching[feedUrl]) {
+        feedFetching[feedUrl] = true;
+        fetch(feedUrl, { cache: 'default' })
+          .then(function (r) { return r.ok ? r.json() : null; })
+          .then(function (data) {
+            feedCache[feedUrl] = data;
+            // Re-render if the same trigger is still showing.
+            if (lastTrigger && lastTrigger.getAttribute('data-hover-feed') === feedUrl &&
+                card.matches(':popover-open')) {
+              clearChildren(inner);
+              inner.appendChild(buildFeedDom(lastTrigger, data));
+              requestAnimationFrame(function () { position(lastTrigger); });
+            }
+          })
+          .catch(function () {
+            feedCache[feedUrl] = null;
+            // Fallback: degrade to the static thumbnail render path.
+            if (lastTrigger === trigger) renderStatic(trigger);
+          });
+      }
+    }
+
+    function open(trigger) {
+      ensureCard();
+      var embedType = trigger.getAttribute('data-hover-embed');
+      if (embedType === 'substack-feed') {
+        renderSubstack(trigger);
+      } else {
+        renderStatic(trigger);
+      }
       if (!card.matches(':popover-open')) {
         try { card.showPopover(); } catch (_) { /* noop */ }
       }
@@ -255,6 +383,25 @@
         if (lastTrigger) lastTrigger.focus();
       }
     });
+
+    // Scroll-aware positioning: the popover is `position: fixed` and
+    // `position(trigger)` previously ran ONCE on open, leaving the
+    // card frozen at its original viewport coordinates while the
+    // trigger drifted away during scroll. Re-call position() on every
+    // scroll/resize while the card is open, throttled via rAF so
+    // momentum-scroll doesn't fire 120 times/second. Capture phase
+    // catches scroll events from internal scrollable containers
+    // (some don't bubble to window).
+    var rafScroll = null;
+    function onScrollOrResize() {
+      if (rafScroll || !card || !card.matches(':popover-open') || !lastTrigger) return;
+      rafScroll = requestAnimationFrame(function () {
+        position(lastTrigger);
+        rafScroll = null;
+      });
+    }
+    window.addEventListener('scroll', onScrollOrResize, { passive: true, capture: true });
+    window.addEventListener('resize', onScrollOrResize, { passive: true });
 
     Array.prototype.forEach.call(triggers, attach);
   }());

--- a/docs/hover-preview-pattern.md
+++ b/docs/hover-preview-pattern.md
@@ -148,3 +148,68 @@ These are deliberate scope reductions per a11y critique; the change satisfies WC
 5. (Optional) Tune `--hover-preview-open-delay` / `--hover-preview-close-grace` / `--hover-preview-fade` to taste — they are CSS custom properties, single-line overrides.
 
 No build step, no framework, no runtime deps.
+
+---
+
+## Live embed mode (Substack)
+
+The default render mode is the static thumbnail + title + caption. A second mode renders a stacked list of recent posts pulled from a periodically-refreshed JSON snapshot — used for Substack publication links.
+
+**Why a snapshot, not a live fetch:** Substack's `/feed` endpoint does not return `Access-Control-Allow-Origin`, so a client-side fetch from a third-party origin (e.g. GitHub Pages) is blocked by CORS. A scheduled GitHub Action runs `scripts/snap-substack-feed.py` every ~4 hours, parses the RSS, writes `static/substack-latest.json`, and commits only if the content changed. The popup then fetches that file from its own origin — no CORS, no third-party tracking, no client-side parsing cost.
+
+### Trigger annotation
+
+```html
+<a href="https://yourpub.substack.com" target="_blank" rel="noreferrer"
+   data-hover-preview="/static/preview-substack.png"
+   data-hover-embed="substack-feed"
+   data-hover-feed="/static/substack-latest.json"
+   data-hover-title="My Substack"
+   data-hover-caption="Weekly notes">
+  Read on Substack
+</a>
+```
+
+`data-hover-preview` stays as a fallback: if the JSON fetch fails (404 / network / CORS), the popup degrades to the static screenshot. `data-hover-title` is reused as the feed-card header.
+
+### JSON contract
+
+```json
+{
+  "publication": "Naren's Substack",
+  "url": "https://narendranathe.substack.com/",
+  "fetched_at": "2026-05-01T18:00:00Z",
+  "posts": [
+    {
+      "title": "...",
+      "url": "https://narendranathe.substack.com/p/...",
+      "published_at": "2026-04-28T15:30:00Z",
+      "excerpt": "..."
+    }
+  ]
+}
+```
+
+Top 3 posts only. Excerpts are HTML-stripped + truncated to ~220 chars by the parser. Test gates in `scripts/test-portfolio.py` enforce this shape.
+
+### Adopter checklist
+
+1. Copy `scripts/snap-substack-feed.py` and adjust the default feed URL.
+2. Copy `.github/workflows/substack-snapshot.yml` and adjust the cron cadence to match your post frequency.
+3. Run the script once locally to seed `static/substack-latest.json` so the popup works on first visit before the cron has fired.
+4. Add `data-hover-embed="substack-feed"` + `data-hover-feed="/static/substack-latest.json"` to your Substack triggers.
+5. Confirm `permissions: contents: write` is set in the workflow so it can commit the refreshed JSON back to the repo.
+
+Mobile path is unchanged: touch devices skip the popover entirely (`@media (hover: none) and (pointer: coarse)`), so the live-feed mode is desktop-only.
+
+---
+
+## Scroll-aware positioning
+
+The popover is `position: fixed` and `position(trigger)` originally ran ONCE on open via `getBoundingClientRect()` (viewport coordinates). When the user scrolled afterwards, the trigger moved but the popover stayed frozen — drifting visually away. v2 adds a `scroll` + `resize` listener (capture phase, passive, rAF-throttled) that re-runs `position(lastTrigger)` while the popover is open. The position function also clamps `top` to viewport bounds so the popover stays on-screen even when the trigger has scrolled partly off-screen.
+
+---
+
+## LinkedIn limitation
+
+`<iframe src="linkedin.com/in/...">` is blocked by `X-Frame-Options: SAMEORIGIN`, LinkedIn's OEmbed endpoint returns 404, and there is no public unauth API. The Profile Badge widget only works for profiles the owner has explicitly enabled. **Conclusion:** LinkedIn triggers must use the static-thumbnail render mode. The static `/static/preview-linkedin.png` is the ceiling; do not promise live LinkedIn previews.

--- a/docs/hover-preview-pattern.md
+++ b/docs/hover-preview-pattern.md
@@ -160,6 +160,7 @@ The default render mode is the static thumbnail + title + caption. A second mode
 ### Trigger annotation
 
 ```html
+<!-- Publication-root link: shows the 3 most-recent posts -->
 <a href="https://yourpub.substack.com" target="_blank" rel="noreferrer"
    data-hover-preview="/static/preview-substack.png"
    data-hover-embed="substack-feed"
@@ -168,7 +169,23 @@ The default render mode is the static thumbnail + title + caption. A second mode
    data-hover-caption="Weekly notes">
   Read on Substack
 </a>
+
+<!-- Specific-post link: pins THAT post first, then the 2 next
+     most-recent posts after it -->
+<a href="https://yourpub.substack.com/p/karpathys-llm-wiki-applied-to-a-multi"
+   target="_blank" rel="noreferrer"
+   data-hover-preview="/static/preview-substack.png"
+   data-hover-embed="substack-feed"
+   data-hover-feed="/static/substack-latest.json"
+   data-hover-title="Karpathy's LLM Wiki, applied"
+   data-hover-caption="GraphRAG implementation">
+  Read on Substack
+</a>
 ```
+
+**Per-trigger pin behavior:** the JS reads the trigger's `href`. If that URL matches one of the posts in the JSON, that post is rendered FIRST in the popup, followed by the 2 next most-recent posts (excluding the pinned one). For root-URL triggers — or triggers whose href doesn't match any post — the popup falls back to the top-3-most-recent default. URL match is normalized: trailing slash and `#fragment` are ignored, so `…/p/foo` and `…/p/foo/#section` resolve to the same post.
+
+**Why the parser keeps 10 posts even though the popup shows 3:** so the per-trigger pin lookup can resolve older posts that are no longer in the absolute top 3. Adjust `MAX_POSTS` in `scripts/snap-substack-feed.py` if you have a long-tailed publication and want the pin to find further-back posts.
 
 `data-hover-preview` stays as a fallback: if the JSON fetch fails (404 / network / CORS), the popup degrades to the static screenshot. `data-hover-title` is reused as the feed-card header.
 

--- a/index.html
+++ b/index.html
@@ -1016,7 +1016,7 @@
             <span class="writing-label">AI infra &middot; draft &middot; on Substack</span>
             <h3 class="writing-title">The LLM cascade as a routing system, not a fallback.</h3>
             <p class="writing-desc">Five providers, circuit breakers per provider, per-category routing, and a reward loop. What worked: Claude-first with cost-aware overflow. What didn't: naive failover by HTTP status code &mdash; LLMs fail in much weirder ways than 500s.</p>
-            <a href="https://narendranathe.substack.com" class="cs-btn cs-btn--substack writing-cta" target="_blank" rel="noreferrer"
+            <a href="https://narendranathe.substack.com/p/karpathys-llm-wiki-applied-to-a-multi" class="cs-btn cs-btn--substack writing-cta" target="_blank" rel="noreferrer"
                data-hover-preview="/static/preview-substack.png"
                data-hover-embed="substack-feed"
                data-hover-feed="/static/substack-latest.json"
@@ -1101,7 +1101,7 @@
             <span class="writing-label">AI systems</span>
             <h3 class="writing-title">The LLM Cascade as a Routing System, Not a Fallback</h3>
             <p class="writing-desc">Five providers, circuit breakers, per-category routing, and a reward loop. Why the model routing layer is the most interesting engineering surface in AutoApply AI.</p>
-            <a href="https://narendranathe.substack.com" class="cs-btn cs-btn--substack writing-cta" target="_blank" rel="noreferrer"
+            <a href="https://narendranathe.substack.com/p/karpathys-llm-wiki-applied-to-a-multi" class="cs-btn cs-btn--substack writing-cta" target="_blank" rel="noreferrer"
                data-hover-preview="/static/preview-substack.png"
                data-hover-embed="substack-feed"
                data-hover-feed="/static/substack-latest.json"

--- a/index.html
+++ b/index.html
@@ -1018,6 +1018,8 @@
             <p class="writing-desc">Five providers, circuit breakers per provider, per-category routing, and a reward loop. What worked: Claude-first with cost-aware overflow. What didn't: naive failover by HTTP status code &mdash; LLMs fail in much weirder ways than 500s.</p>
             <a href="https://narendranathe.substack.com" class="cs-btn cs-btn--substack writing-cta" target="_blank" rel="noreferrer"
                data-hover-preview="/static/preview-substack.png"
+               data-hover-embed="substack-feed"
+               data-hover-feed="/static/substack-latest.json"
                data-hover-title="Substack - narendranathe"
                data-hover-caption="AI infra notes, weekly cadence">Read on Substack &rarr;</a>
           </article>
@@ -1052,6 +1054,8 @@
             <p class="writing-desc">CI/CD ownership at ExponentHR &mdash; Azure DevOps pipelines, idempotent CDC ETL with merge-upserts, AAG copy-down automation. Honest tradeoffs section: which gates I tried to remove and learned to keep.</p>
             <a href="https://narendranathe.substack.com" class="cs-btn cs-btn--substack writing-cta" target="_blank" rel="noreferrer"
                data-hover-preview="/static/preview-substack.png"
+               data-hover-embed="substack-feed"
+               data-hover-feed="/static/substack-latest.json"
                data-hover-title="Substack - narendranathe"
                data-hover-caption="AI infra notes, weekly cadence">Read on Substack &rarr;</a>
           </article>
@@ -1077,6 +1081,8 @@
             <p class="writing-desc">Why one generic form handler is the wrong abstraction when ATS platforms vary by DOM isolation, field detection logic, and submission behavior.</p>
             <a href="https://narendranathe.substack.com" class="cs-btn cs-btn--substack writing-cta" target="_blank" rel="noreferrer"
                data-hover-preview="/static/preview-substack.png"
+               data-hover-embed="substack-feed"
+               data-hover-feed="/static/substack-latest.json"
                data-hover-title="Substack - narendranathe"
                data-hover-caption="AI infra notes, weekly cadence">Read on Substack</a>
           </article>
@@ -1086,6 +1092,8 @@
             <p class="writing-desc">A seemingly simple boolean flag caused a state bug that took three false fixes before the real model emerged. What it taught about representing apply state.</p>
             <a href="https://narendranathe.substack.com" class="cs-btn cs-btn--substack writing-cta" target="_blank" rel="noreferrer"
                data-hover-preview="/static/preview-substack.png"
+               data-hover-embed="substack-feed"
+               data-hover-feed="/static/substack-latest.json"
                data-hover-title="Substack - narendranathe"
                data-hover-caption="AI infra notes, weekly cadence">Read on Substack</a>
           </article>
@@ -1095,6 +1103,8 @@
             <p class="writing-desc">Five providers, circuit breakers, per-category routing, and a reward loop. Why the model routing layer is the most interesting engineering surface in AutoApply AI.</p>
             <a href="https://narendranathe.substack.com" class="cs-btn cs-btn--substack writing-cta" target="_blank" rel="noreferrer"
                data-hover-preview="/static/preview-substack.png"
+               data-hover-embed="substack-feed"
+               data-hover-feed="/static/substack-latest.json"
                data-hover-title="Substack - narendranathe"
                data-hover-caption="AI infra notes, weekly cadence">Read on Substack</a>
           </article>
@@ -1111,6 +1121,8 @@
         <div class="section-cta" data-reveal>
           <a href="https://narendranathe.substack.com" class="btn btn-substack" target="_blank" rel="noreferrer"
              data-hover-preview="/static/preview-substack.png"
+             data-hover-embed="substack-feed"
+             data-hover-feed="/static/substack-latest.json"
              data-hover-title="Substack - narendranathe"
              data-hover-caption="AI infra notes, weekly cadence"><svg class="substack-logo" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M22.539 8.242H1.46V5.406h21.08v2.836zM1.46 10.812V24L12 18.11 22.54 24V10.812H1.46zM22.54 0H1.46v2.836h21.08V0z"/></svg>Follow on Substack</a>
         </div>
@@ -1181,6 +1193,8 @@
           </a>
           <a href="https://narendranathe.substack.com" class="btn peer-cta-btn peer-cta-btn--substack" target="_blank" rel="noreferrer"
              data-hover-preview="/static/preview-substack.png"
+             data-hover-embed="substack-feed"
+             data-hover-feed="/static/substack-latest.json"
              data-hover-title="Substack - narendranathe"
              data-hover-caption="AI infra notes, weekly cadence">
             <svg viewBox="0 0 24 24" fill="currentColor" style="width:16px;height:16px;flex-shrink:0" aria-hidden="true"><path d="M22.539 8.242H1.46V5.406h21.08v2.836zM1.46 10.812V24L12 18.11 22.54 24V10.812H1.46zM22.54 0H1.46v2.836h21.08V0z"/></svg> Follow on Substack
@@ -1225,6 +1239,8 @@
             </a>
             <a href="https://narendranathe.substack.com" target="_blank" rel="noreferrer" class="contact-link contact-substack"
                data-hover-preview="/static/preview-substack.png"
+               data-hover-embed="substack-feed"
+               data-hover-feed="/static/substack-latest.json"
                data-hover-title="Substack - narendranathe"
                data-hover-caption="AI infra notes, weekly cadence">
               <i class="fas fa-newspaper"></i><span>Follow my writing on Substack</span>
@@ -1266,6 +1282,8 @@
            data-hover-caption="Senior AI/ML Engineer - open to remote"><i class="fab fa-linkedin-in"></i></a>
         <a href="https://narendranathe.substack.com" target="_blank" rel="noreferrer" aria-label="Substack"
            data-hover-preview="/static/preview-substack.png"
+           data-hover-embed="substack-feed"
+           data-hover-feed="/static/substack-latest.json"
            data-hover-title="Substack - narendranathe"
            data-hover-caption="AI infra notes, weekly cadence"><i class="fas fa-newspaper"></i></a>
         <a href="mailto:edara.narendranath@gmail.com" aria-label="Email"><i class="fas fa-envelope"></i></a>

--- a/scripts/snap-substack-feed.py
+++ b/scripts/snap-substack-feed.py
@@ -48,7 +48,9 @@ DEFAULT_FEED = "https://narendranathe.substack.com/feed"
 TARGET = REPO_ROOT / "static" / "substack-latest.json"
 TIMEOUT_S = 15
 USER_AGENT = "Mozilla/5.0 (compatible; PortfolioSubstackSnap/1.0)"
-MAX_POSTS = 3
+MAX_POSTS = 10  # popup shows max 3 at a time, but we keep 10 in the JSON so
+                # the per-trigger pin lookup (href -> post) can resolve older
+                # posts that aren't in the absolute top 3 anymore.
 EXCERPT_MAX_CHARS = 220
 # Substack uses <content:encoded> in the content namespace; we read
 # <description> instead (always present, plain HTML, shorter for excerpts).

--- a/scripts/snap-substack-feed.py
+++ b/scripts/snap-substack-feed.py
@@ -1,0 +1,159 @@
+"""Fetch the latest posts from a Substack publication's RSS feed and
+write a same-origin JSON snapshot the hover-preview popup can consume.
+
+Why a snapshot, not a live fetch:
+- Substack's /feed endpoint does NOT return Access-Control-Allow-Origin,
+  so client-side fetch from narendranathe.github.io is blocked by CORS.
+- A periodic GitHub Action runs this script on a cron, writes the JSON
+  to static/substack-latest.json, and commits only if the content has
+  changed. Same-origin fetch from the popup, no CORS, no third-party
+  tracking, no client-side parsing cost.
+
+Output shape (stable contract — see hover-preview-pattern.md):
+    {
+      "publication": "Naren's Substack",
+      "url": "https://narendranathe.substack.com/",
+      "fetched_at": "2026-05-01T18:00:00Z",
+      "posts": [
+        {
+          "title": "...",
+          "url": "https://...",
+          "published_at": "2026-04-28T15:30:00Z",
+          "excerpt": "..."
+        },
+        ...
+      ]
+    }
+
+Usage
+-----
+    python scripts/snap-substack-feed.py
+    python scripts/snap-substack-feed.py --feed https://example.substack.com/feed
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import html
+import json
+import re
+import sys
+import urllib.error
+import urllib.request
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_FEED = "https://narendranathe.substack.com/feed"
+TARGET = REPO_ROOT / "static" / "substack-latest.json"
+TIMEOUT_S = 15
+USER_AGENT = "Mozilla/5.0 (compatible; PortfolioSubstackSnap/1.0)"
+MAX_POSTS = 3
+EXCERPT_MAX_CHARS = 220
+# Substack uses <content:encoded> in the content namespace; we read
+# <description> instead (always present, plain HTML, shorter for excerpts).
+NS = {"content": "http://purl.org/rss/1.0/modules/content/"}
+
+# Strip ALL HTML tags (Substack descriptions are HTML); collapse whitespace.
+_TAG_RE = re.compile(r"<[^>]+>")
+_WS_RE = re.compile(r"\s+")
+
+
+def fetch_feed(url: str) -> str:
+    req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    with urllib.request.urlopen(req, timeout=TIMEOUT_S) as resp:
+        return resp.read().decode("utf-8")
+
+
+def parse_rfc822(date_str: str) -> str:
+    """RSS 2.0 uses RFC 822 dates ("Mon, 28 Apr 2026 15:30:00 GMT").
+    Convert to ISO-8601 UTC for the JSON output. Returns the input
+    unchanged if parsing fails (better than dropping the field)."""
+    try:
+        # email.utils handles RFC 822 robustly
+        from email.utils import parsedate_to_datetime
+        d = parsedate_to_datetime(date_str)
+        if d is None:
+            return date_str
+        if d.tzinfo is None:
+            d = d.replace(tzinfo=dt.timezone.utc)
+        return d.astimezone(dt.timezone.utc).isoformat().replace("+00:00", "Z")
+    except Exception:  # noqa: BLE001
+        return date_str
+
+
+def html_to_excerpt(s: str, max_chars: int = EXCERPT_MAX_CHARS) -> str:
+    if not s:
+        return ""
+    # Strip tags, decode HTML entities, collapse whitespace
+    plain = _TAG_RE.sub(" ", s)
+    plain = html.unescape(plain)
+    plain = _WS_RE.sub(" ", plain).strip()
+    if len(plain) <= max_chars:
+        return plain
+    cut = plain[:max_chars].rsplit(" ", 1)[0]
+    return cut + "..."
+
+
+def parse_feed(xml_text: str) -> dict:
+    root = ET.fromstring(xml_text)
+    channel = root.find("channel")
+    if channel is None:
+        raise ValueError("RSS feed has no <channel>")
+
+    publication = (channel.findtext("title") or "Substack").strip()
+    site_url = (channel.findtext("link") or "").strip()
+
+    posts: list[dict] = []
+    for item in channel.findall("item")[:MAX_POSTS]:
+        title = (item.findtext("title") or "").strip()
+        link = (item.findtext("link") or "").strip()
+        pub_date = parse_rfc822((item.findtext("pubDate") or "").strip())
+        excerpt = html_to_excerpt(item.findtext("description") or "")
+        if title and link:
+            posts.append({
+                "title": title,
+                "url": link,
+                "published_at": pub_date,
+                "excerpt": excerpt,
+            })
+
+    return {
+        "publication": publication,
+        "url": site_url,
+        "fetched_at": dt.datetime.now(dt.timezone.utc).isoformat().replace("+00:00", "Z"),
+        "posts": posts,
+    }
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--feed", default=DEFAULT_FEED, help="Substack RSS feed URL")
+    p.add_argument("--out", default=str(TARGET), help="Output JSON path")
+    args = p.parse_args()
+
+    try:
+        xml_text = fetch_feed(args.feed)
+    except urllib.error.URLError as exc:
+        print(f"fetch failed: {exc}", file=sys.stderr)
+        return 1
+    except TimeoutError as exc:
+        print(f"fetch timeout: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        snapshot = parse_feed(xml_text)
+    except (ET.ParseError, ValueError) as exc:
+        print(f"parse failed: {exc}", file=sys.stderr)
+        return 1
+
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(snapshot, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+    print(f"wrote {len(snapshot['posts'])} posts to {out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test-portfolio.py
+++ b/scripts/test-portfolio.py
@@ -799,8 +799,11 @@ def test_substack_snapshot_json_schema() -> None:
     for key in ("publication", "url", "fetched_at", "posts"):
         assert key in data, f"substack-latest.json missing required field: {key}"
     assert isinstance(data["posts"], list), "posts must be a list"
-    assert 0 <= len(data["posts"]) <= 5, (
-        f"posts length {len(data['posts'])} unexpected; parser caps at 3"
+    # Parser keeps up to 10 posts so the per-trigger pin lookup can
+    # resolve older posts that aren't in the absolute top 3 anymore.
+    # The popup itself only shows max 3 at a time.
+    assert 0 <= len(data["posts"]) <= 10, (
+        f"posts length {len(data['posts'])} unexpected; parser caps at 10"
     )
     if data["posts"]:
         post = data["posts"][0]
@@ -836,15 +839,19 @@ def test_substack_triggers_have_embed_attrs(html: str) -> None:
 
 
 def test_app_js_has_substack_render_branch() -> None:
-    """app.js must implement the renderSubstack branch and the scroll-
-    aware repositioning listener; without either, the live-feed mode
-    is half-built."""
+    """app.js must implement the renderSubstack branch, the per-trigger
+    pin selector, and the scroll-aware repositioning listener; without
+    any one of them, the live-feed mode is half-built."""
     js = APP_JS.read_text(encoding="utf-8")
     assert "renderSubstack" in js, (
         "app.js missing renderSubstack() — live-feed render branch absent"
     )
     assert "buildFeedDom" in js, (
         "app.js missing buildFeedDom() — feed list construction absent"
+    )
+    assert "selectPostsForTrigger" in js, (
+        "app.js missing selectPostsForTrigger() — per-trigger pin lookup "
+        "(href -> matching post first, then 2 most recent) absent"
     )
     assert "data-hover-embed" in js, (
         "app.js never reads data-hover-embed attribute — render branch dead code"

--- a/scripts/test-portfolio.py
+++ b/scripts/test-portfolio.py
@@ -765,6 +765,107 @@ def test_hover_preview_pattern_doc_present() -> None:
     assert len(body) > 1000, f"pattern doc body is only {len(body)} chars; expected >= 1000"
 
 
+# ===== Substack live-feed mode (hover-preview v2 follow-up) =====
+
+SUBSTACK_SNAPSHOT_JSON = REPO_ROOT / "static" / "substack-latest.json"
+SUBSTACK_SNAP_SCRIPT = REPO_ROOT / "scripts" / "snap-substack-feed.py"
+SUBSTACK_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "substack-snapshot.yml"
+
+
+def test_substack_snapshot_pipeline_present() -> None:
+    """The Substack live-feed render mode depends on three artifacts
+    being shipped together: the parser script, the cron workflow, and
+    a same-origin JSON snapshot. Removing any one breaks the popup."""
+    assert SUBSTACK_SNAP_SCRIPT.exists(), (
+        "scripts/snap-substack-feed.py missing — needed by the cron workflow"
+    )
+    assert SUBSTACK_WORKFLOW.exists(), (
+        ".github/workflows/substack-snapshot.yml missing — without this the "
+        "JSON snapshot never refreshes after the seed commit"
+    )
+    assert SUBSTACK_SNAPSHOT_JSON.exists(), (
+        "static/substack-latest.json missing — the popup will 404 on hover. "
+        "Run: python scripts/snap-substack-feed.py"
+    )
+
+
+def test_substack_snapshot_json_schema() -> None:
+    """The JSON shape is the contract between the parser + the popup
+    renderer. Any change here MUST update both buildFeedDom() in app.js
+    AND the parser; this test catches drift."""
+    import json
+    body = SUBSTACK_SNAPSHOT_JSON.read_text(encoding="utf-8")
+    data = json.loads(body)
+    for key in ("publication", "url", "fetched_at", "posts"):
+        assert key in data, f"substack-latest.json missing required field: {key}"
+    assert isinstance(data["posts"], list), "posts must be a list"
+    assert 0 <= len(data["posts"]) <= 5, (
+        f"posts length {len(data['posts'])} unexpected; parser caps at 3"
+    )
+    if data["posts"]:
+        post = data["posts"][0]
+        for key in ("title", "url", "published_at", "excerpt"):
+            assert key in post, f"post entry missing field: {key}"
+        assert post["url"].startswith("http"), "post.url must be an absolute URL"
+
+
+def test_substack_triggers_have_embed_attrs(html: str) -> None:
+    """Every <a> link to narendranathe.substack.com that uses the
+    hover-preview MUST also declare data-hover-embed=\"substack-feed\"
+    and data-hover-feed=\"/static/substack-latest.json\". Without these,
+    the live-feed render mode falls back to the static screenshot."""
+    # Find every Substack-targeted anchor that has data-hover-preview
+    pattern = re.compile(
+        r'<a\s+href="https://[^"]*substack\.com[^"]*"[^>]*data-hover-preview',
+        flags=re.S,
+    )
+    anchors = pattern.findall(html)
+    assert anchors, "no Substack hover-preview triggers found"
+    # Each one of those anchor opening tags must include the embed attrs.
+    # Use a wider re.search per occurrence.
+    embed_count = len(re.findall(
+        r'<a\s+href="https://[^"]*substack\.com[^>]*?data-hover-embed="substack-feed"',
+        html,
+        flags=re.S,
+    ))
+    assert embed_count == len(anchors), (
+        f"{len(anchors)} Substack hover triggers found, but only {embed_count} "
+        f"declare data-hover-embed=\"substack-feed\". Each Substack trigger "
+        f"must opt in to the live-feed render mode."
+    )
+
+
+def test_app_js_has_substack_render_branch() -> None:
+    """app.js must implement the renderSubstack branch and the scroll-
+    aware repositioning listener; without either, the live-feed mode
+    is half-built."""
+    js = APP_JS.read_text(encoding="utf-8")
+    assert "renderSubstack" in js, (
+        "app.js missing renderSubstack() — live-feed render branch absent"
+    )
+    assert "buildFeedDom" in js, (
+        "app.js missing buildFeedDom() — feed list construction absent"
+    )
+    assert "data-hover-embed" in js, (
+        "app.js never reads data-hover-embed attribute — render branch dead code"
+    )
+    # Scroll-aware reposition listener: scroll OR resize handler that
+    # re-runs position(lastTrigger). Substring-match is canary-level
+    # but catches a regression where someone removes the listener.
+    assert "onScrollOrResize" in js or "scroll" in js.lower(), (
+        "app.js missing scroll listener that re-positions the popover"
+    )
+
+
+def test_styles_css_has_feed_list_module() -> None:
+    """The .hp-feed-* CSS module renders the live-posts list in the
+    smaller card. Removing it would leave the JS-built DOM unstyled."""
+    css = STYLES_CSS.read_text(encoding="utf-8")
+    for selector in (".hp-feed-header", ".hp-feed-list", ".hp-feed-item",
+                     ".hp-feed-title", ".hp-feed-meta", ".hp-feed-empty"):
+        assert selector in css, f"styles.css missing {selector} rule"
+
+
 def _skills_section_html(html: str) -> str:
     """Extract the inner HTML of the <section id="skills"> block, raising
     AssertionError if the section is missing or malformed. Reused by the
@@ -1034,6 +1135,12 @@ TESTS = [
     test_hover_preview_companion_attrs_present,
     test_hover_preview_no_role_dialog,
     test_hover_preview_pattern_doc_present,
+    # ----- Substack live-feed mode (hover-preview v2 follow-up) -----
+    test_substack_snapshot_pipeline_present,
+    test_substack_snapshot_json_schema,
+    test_substack_triggers_have_embed_attrs,
+    test_app_js_has_substack_render_branch,
+    test_styles_css_has_feed_list_module,
     # ----- Skills grid (issue #71) -----
     test_skills_section_present,
     test_skills_nav_link_present,

--- a/static/substack-latest.json
+++ b/static/substack-latest.json
@@ -1,0 +1,25 @@
+{
+  "publication": "Narendranath Edara",
+  "url": "https://narendranathe.substack.com",
+  "fetched_at": "2026-05-01T18:44:51.937488Z",
+  "posts": [
+    {
+      "title": "Karpathy’s LLM Wiki, applied to a multi-repo system - what changes and what doesn’t",
+      "url": "https://narendranathe.substack.com/p/karpathys-llm-wiki-applied-to-a-multi",
+      "published_at": "2026-04-21T13:11:57Z",
+      "excerpt": "GraphRAG implementation"
+    },
+    {
+      "title": "I built a resume tailoring tool with Claude Code",
+      "url": "https://narendranathe.substack.com/p/i-built-a-resume-tailoring-tool-with",
+      "published_at": "2026-03-19T23:51:50Z",
+      "excerpt": "Your ability to get a job should not depend on your resume writing skills."
+    },
+    {
+      "title": "I Built a Cinematic Website in 10 Minutes Using Claude AI. Here’s Every Technical Decision I Made.",
+      "url": "https://narendranathe.substack.com/p/i-built-a-cinematic-website-in-10",
+      "published_at": "2026-02-07T21:43:11Z",
+      "excerpt": "What used to take days now takes minutes. But the engineering knowledge that makes it possible hasn’t changed."
+    }
+  ]
+}

--- a/static/substack-latest.json
+++ b/static/substack-latest.json
@@ -1,7 +1,7 @@
 {
   "publication": "Narendranath Edara",
   "url": "https://narendranathe.substack.com",
-  "fetched_at": "2026-05-01T18:44:51.937488Z",
+  "fetched_at": "2026-05-02T01:19:27.118911Z",
   "posts": [
     {
       "title": "Karpathy’s LLM Wiki, applied to a multi-repo system - what changes and what doesn’t",
@@ -20,6 +20,48 @@
       "url": "https://narendranathe.substack.com/p/i-built-a-cinematic-website-in-10",
       "published_at": "2026-02-07T21:43:11Z",
       "excerpt": "What used to take days now takes minutes. But the engineering knowledge that makes it possible hasn’t changed."
+    },
+    {
+      "title": "Building My Portfolio: A Journey Through Design Decisions, Bugs, and Late-Night Debugging",
+      "url": "https://narendranathe.substack.com/p/building-my-portfolio-a-journey-through",
+      "published_at": "2026-01-30T14:34:16Z",
+      "excerpt": "From a blank HTML file to a dynamic, config-driven portfolio — here’s everything that worked, everything that broke, and what I learned along the way."
+    },
+    {
+      "title": "Building Real-Time Portfolio Risk Analytics",
+      "url": "https://narendranathe.substack.com/p/building-real-time-portfolio-risk",
+      "published_at": "2025-12-31T16:09:37Z",
+      "excerpt": "From 24-Hour Batch Jobs to 5-Second Insights"
+    },
+    {
+      "title": "Compute Cost ≠ Cloud Cost: Fix Architecture, Save Budget",
+      "url": "https://narendranathe.substack.com/p/compute-cost-cloud-cost-fix-architecture",
+      "published_at": "2025-12-08T14:21:49Z",
+      "excerpt": "A real incident that shows why workload isolation, observability, and replica testing matter more than chasing costs."
+    },
+    {
+      "title": "Row-Level Security (RLS) in SQL",
+      "url": "https://narendranathe.substack.com/p/row-level-security-rls-in-sql",
+      "published_at": "2025-09-29T12:57:24Z",
+      "excerpt": "Ensuring Fine-Grained Data Access Control"
+    },
+    {
+      "title": "Cross-Database Queries and Linked Servers",
+      "url": "https://narendranathe.substack.com/p/cross-database-queries-and-linked",
+      "published_at": "2025-09-26T12:49:26Z",
+      "excerpt": "Practical Patterns, Pitfalls, and Playbooks"
+    },
+    {
+      "title": "Temporal Tables and System-Versioned Tables",
+      "url": "https://narendranathe.substack.com/p/temporal-tables-and-system-versioned",
+      "published_at": "2025-09-24T13:07:48Z",
+      "excerpt": "Making Time Your Data’s Ally"
+    },
+    {
+      "title": "Window Frame Specification in SQL",
+      "url": "https://narendranathe.substack.com/p/window-frame-specification-in-sql",
+      "published_at": "2025-09-22T12:44:23Z",
+      "excerpt": "Precision Analytics at Scale"
     }
   ]
 }

--- a/styles.css
+++ b/styles.css
@@ -1629,13 +1629,13 @@ body.splash-active { overflow: hidden; }
 .hover-preview-card {
   display: grid;
   grid-template-rows: auto auto;
-  gap: 0.625rem;
-  width: 264px;
-  padding: 0.875rem;
+  gap: 0.5rem;
+  width: 220px;
+  padding: 0.625rem;
   background: var(--bg);
   color: var(--fg);
   border: 1px solid var(--border);
-  border-radius: 14px;
+  border-radius: 12px;
   box-shadow:
     0 1px 2px rgba(0, 0, 0, 0.06),
     0 14px 36px -8px rgba(20, 14, 8, 0.22);
@@ -1649,10 +1649,10 @@ body.splash-active { overflow: hidden; }
   display: block;
   width: 100%;
   height: auto;
-  aspect-ratio: 240 / 320;
-  border-radius: 10px;
+  aspect-ratio: 4 / 3;
+  border-radius: 8px;
   background: #ffffff;
-  object-fit: contain;
+  object-fit: cover;
   opacity: 0;
   transform: scale(0.985);
   transition:
@@ -1689,9 +1689,76 @@ body.splash-active { overflow: hidden; }
 
 .hover-preview-caption {
   margin: 0;
-  font-size: 0.75rem;
+  font-size: 0.72rem;
   color: var(--fg-muted);
-  line-height: 1.45;
+  line-height: 1.4;
+  /* Smaller card means less room for prose; clamp to 2 lines so a
+     long caption never blows up the card height past its sibling tile. */
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+/* Substack live-feed mode: when the trigger has data-hover-embed=
+   "substack-feed", the JS swaps the static thumbnail+title+caption
+   for a stacked list of the 3 most recent posts (title + relative
+   date + 1-line excerpt). Source: build-time JSON snapshot generated
+   by .github/workflows/substack-snapshot.yml — same-origin fetch,
+   no CORS, no third-party tracking. */
+.hp-feed-header {
+  display: flex; align-items: center; gap: 0.4rem;
+  padding-bottom: 0.4rem;
+  border-bottom: 1px solid var(--border);
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 0.66rem; font-weight: 600; letter-spacing: 0.06em;
+  text-transform: uppercase; color: var(--fg-muted);
+}
+.hp-feed-header::before {
+  content: ""; width: 6px; height: 6px;
+  background: var(--accent-warm); border-radius: 50%;
+  flex-shrink: 0;
+}
+.hp-feed-list {
+  display: flex; flex-direction: column;
+  gap: 0.45rem;
+  margin: 0; padding: 0;
+  list-style: none;
+}
+.hp-feed-item {
+  display: block;
+  padding: 0.4rem 0.05rem;
+  border-radius: 6px;
+  text-decoration: none;
+  color: inherit;
+  transition: background 140ms ease;
+}
+.hp-feed-item + .hp-feed-item {
+  border-top: 1px solid var(--border-soft, var(--border));
+}
+.hp-feed-item:hover,
+.hp-feed-item:focus-visible {
+  background: var(--bg-alt);
+  outline: none;
+}
+.hp-feed-title {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  margin: 0 0 0.15rem;
+  font-size: 0.78rem; font-weight: 600;
+  line-height: 1.3; color: var(--fg);
+}
+.hp-feed-meta {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 0.64rem; color: var(--fg-muted);
+  letter-spacing: 0.02em;
+}
+.hp-feed-empty {
+  padding: 0.6rem 0;
+  font-size: 0.72rem; color: var(--fg-muted);
+  font-style: italic;
 }
 
 /* Touch devices: hide the popover entirely. Mobile users get the


### PR DESCRIPTION
## Summary

User feedback after the PR #82 critique loop:
- popup was too big and stayed frozen at original viewport coords while the trigger drifted away during scroll
- Substack popups should render LIVE post content, not a static \"preview\" screenshot
- LinkedIn: confirmed that no live path exists — static screenshot stays

3 critique agents validated the technical feasibility before implementation:
- **Agent A** (feasibility) confirmed Substack `/feed` blocks CORS for client-side fetch; build-time JSON snapshot is the right path. LinkedIn has no live path at all.
- **Agent B** (UX) found the real bug: `position()` ran ONCE on open. Adding a `scroll` + `resize` listener that re-runs it is ~22 LOC.
- **Agent C** (minimal-change) sketched the implementation — followed here.

## What ships

### Wave 1 — smaller + scroll-aware (~22 LOC, pure CSS + JS)

- \`.hover-preview-card\` shrinks 264→220 px, padding 0.875→0.625, border-radius 14→12. Thumb aspect 240/320 → 4/3. Caption clamped to 2 lines.
- New \`scroll\` + \`resize\` listener (capture-phase, passive, rAF-throttled) re-runs \`position(lastTrigger)\` while the popover is open. Was the actual root cause of the \"align with scroll\" complaint.
- \`position()\` clamps top to viewport bounds so the popover stays visible even when the trigger has scrolled partly off-screen.

### Wave 2 — Substack live render (~120 LOC)

- **\`scripts/snap-substack-feed.py\`** — stdlib-only RSS parser. Fetches publication feed via urllib, parses with ElementTree, extracts top 3 posts (title / URL / RFC822→ISO pubDate / HTML-stripped 220-char excerpt), writes JSON.
- **\`.github/workflows/substack-snapshot.yml\`** — cron every 4 hours + manual dispatch. Commits JSON only if changed (\`[skip ci]\` to avoid recursive deploys). \`permissions: contents: write\`.
- **\`static/substack-latest.json\`** — seed file (3 current posts) so the popup works on day 1 before the first cron run.
- **\`app.js\`** — new render-mode branch in \`open()\`. When trigger has \`data-hover-embed=\"substack-feed\"\`, calls \`renderSubstack()\` which fetches the same-origin JSON, builds a stacked list of top 3 posts, caches per feed URL. On fetch failure: degrades to the static thumbnail path.
- **\`styles.css\`** — new \`.hp-feed-*\` module (~70 LOC) styling the publication header + post-list inside the smaller card.
- **\`index.html\`** — \`data-hover-embed=\"substack-feed\"\` + \`data-hover-feed=\"/static/substack-latest.json\"\` added to all 9 Substack triggers (4 article CTAs + hero follow + 3 contact-area links + footer).
- **\`docs/hover-preview-pattern.md\`** — appended Live-embed-mode + Scroll-aware-positioning + LinkedIn-limitation sections.

### LinkedIn — deliberately unchanged

Every live path is blocked: \`X-Frame-Options: SAMEORIGIN\`, OEmbed returns 404, no unauth API, profile-badge widget requires owner opt-in. Static screenshot is the technical ceiling.

## Test gates added (5)

- \`test_substack_snapshot_pipeline_present\` (script + workflow + json all shipped together)
- \`test_substack_snapshot_json_schema\` (contract enforced between parser + popup renderer)
- \`test_substack_triggers_have_embed_attrs\` (every Substack trigger opts in to live-feed mode)
- \`test_app_js_has_substack_render_branch\` (renderSubstack + buildFeedDom + scroll listener present)
- \`test_styles_css_has_feed_list_module\` (\`.hp-feed-*\` selectors present)

**60/60 self-test assertions pass.**

## Honest tradeoffs

- Snapshot freshness is bounded by the cron cadence (4h) — not truly live. Indistinguishable to a recruiter who lands on the page once; if Naren posts twice in 4h the second is delayed.
- First-hover on a Substack trigger has a one-time fetch latency (~80-200ms for the 1-3KB JSON, cached after that).
- LinkedIn stays static — no live path technically possible.
- Smaller card loses some \"sales-pitch\" feel on resume preview; intentional per user request.

## Diff stats

\`\`\`
8 files changed, 653 insertions(+), 11 deletions(-)
\`\`\`

## Test plan

- [x] 60/60 self-test assertions pass
- [x] \`python scripts/snap-substack-feed.py\` produces valid JSON locally
- [ ] After merge: confirm GH Action runs successfully on first cron fire
- [ ] Visual: hover any Substack link in DevTools desktop — see live posts
- [ ] Visual: scroll while popup is open — popup follows trigger
- [ ] Visual: hover LinkedIn / GitHub / resume — static thumbnail still renders correctly (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)