### PR TITLE
chore(ci): deploy on push to main only

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,7 @@
 name: Deploy to GitHub Pages
 on:
   push:
-    branches: [main, feat/portfolio-apex]
+    branches: [main]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Trims the deploy trigger from `[main, feat/portfolio-apex]` to `[main]`. `feat/portfolio-apex` merged into main via PR #45 and is no longer the deploy target — main is. Manual `workflow_dispatch` still works on any branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)