### PR TITLE
ci(verify-links): weekly --live cron + concurrency (closes #84)

### DIFF
--- a/.github/workflows/verify-links-live.yml
+++ b/.github/workflows/verify-links-live.yml
@@ -1,0 +1,96 @@
+name: Verify links (live external)
+
+# Weekly health check on every external link in the portfolio. The
+# local-only verifier runs in CI on every PR; this --live run catches
+# external link rot (LinkedIn URLs going stale, GitHub repos renamed,
+# OSS projects archived) that the local check can't see.
+#
+# Failure mode: opens a GitHub issue tagged `link-rot` with the
+# verifier output. Does NOT block any other workflow — link rot is a
+# nudge, not an emergency.
+#
+# See scripts/verify-links.py for the verifier itself.
+
+on:
+  schedule:
+    # Mondays at 14:00 UTC = 9am CDT. Pairs with the existing portfolio
+    # cadence (most other automations fire weekday mornings CDT).
+    - cron: '0 14 * * 1'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write  # to open the link-rot issue on failure
+
+concurrency:
+  group: verify-links-live
+  cancel-in-progress: false
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Run --live link verification
+        id: verify
+        # `set +e` so a non-zero exit from the verifier doesn't fail
+        # the step — we want to capture the output and decide what to
+        # do based on whether it succeeded.
+        run: |
+          set +e
+          python scripts/verify-links.py --live > /tmp/verify-output.txt 2>&1
+          rc=$?
+          set -e
+          # Echo to job log
+          cat /tmp/verify-output.txt
+          # Set output flag for the next step
+          if [ $rc -eq 0 ]; then
+            echo "result=ok" >> "$GITHUB_OUTPUT"
+          else
+            echo "result=fail" >> "$GITHUB_OUTPUT"
+          fi
+          # Always exit 0 so the workflow can proceed to issue-filing
+          exit 0
+
+      - name: Open link-rot issue on failure (debounced)
+        if: steps.verify.outputs.result == 'fail'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Debounce: if a link-rot issue is already open, comment on
+          # it instead of opening a new one. Avoids issue-spam on a
+          # weekly cron when a flaky host stays broken.
+          existing=$(gh issue list --state open --label link-rot --json number --jq '.[0].number' 2>/dev/null || echo "")
+          body_file=/tmp/issue-body.md
+          {
+            echo "Weekly --live link verification failed. See full output below."
+            echo
+            echo "**Workflow run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            echo "**Fired at:** $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            echo
+            echo '```'
+            cat /tmp/verify-output.txt
+            echo '```'
+            echo
+            echo "Triage:"
+            echo "1. Reproduce locally: \`python scripts/verify-links.py --live\`"
+            echo "2. If the URL is genuinely dead: update or remove the link in HTML."
+            echo "3. If the URL is bot-walled but valid (verified in a browser): add to \`HOST_ALLOWLIST\` in \`scripts/verify-links.py\`."
+            echo "4. If the host is hostile to verifiers (returns specific status codes): add to \`LENIENT_HOSTS\` mapping."
+          } > "$body_file"
+
+          if [ -n "$existing" ] && [ "$existing" != "null" ]; then
+            echo "issue #$existing already open; appending comment"
+            gh issue comment "$existing" --body-file "$body_file"
+          else
+            echo "opening fresh issue"
+            gh issue create --title "link-rot: weekly --live verification failed" --label link-rot --body-file "$body_file"
+          fi

--- a/scripts/verify-links.py
+++ b/scripts/verify-links.py
@@ -27,6 +27,7 @@ import sys
 import urllib.error
 import urllib.parse
 import urllib.request
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
 from html.parser import HTMLParser
 from pathlib import Path
@@ -71,6 +72,9 @@ LENIENT_HOSTS: dict[str, frozenset[int]] = {
 HOST_ALLOWLIST: frozenset[str] = frozenset({
     "https://www.linkedin.com/in/narendranathe/",
     "https://linkedin.com/in/narendranathe/",
+    # Testimonial-author profiles — manually verified from a real
+    # browser. LinkedIn 404s these to unauthenticated bots.
+    "https://www.linkedin.com/in/pranav-s-47356a58/",
 })
 
 
@@ -278,6 +282,8 @@ def main() -> int:
     p = argparse.ArgumentParser(description="Verify every link on the portfolio resolves.")
     p.add_argument("--live", action="store_true", help="Also check external URLs (slow, network-dependent)")
     p.add_argument("--json", action="store_true", help="Machine-readable JSON output")
+    p.add_argument("--max-workers", type=int, default=8,
+                   help="Parallelism for external (--live) checks. Default 8; raise carefully — high values can trip bot guards on hostile hosts.")
     args = p.parse_args()
 
     files = collect_html_files()
@@ -295,6 +301,7 @@ def main() -> int:
         all_refs.extend(refs)
 
     report = Report()
+    externals_to_check: list[LinkRef] = []
     for ref in all_refs:
         if is_skip(ref.href):
             report.skipped += 1
@@ -309,14 +316,24 @@ def main() -> int:
         if is_external(ref.href):
             report.checked_external += 1
             if args.live:
-                err = check_external(ref)
-                if err:
-                    report.failures.append((ref, err))
+                externals_to_check.append(ref)
             continue
         report.checked_local += 1
         err = check_local(ref, ids_by_file)
         if err:
             report.failures.append((ref, err))
+
+    # External (--live) checks fan out via ThreadPoolExecutor. Sequential
+    # at 72 URLs * 10s timeout each was up to 12 min worst-case; 8 workers
+    # collapses that to ~90 seconds without tripping bot guards.
+    if externals_to_check:
+        with ThreadPoolExecutor(max_workers=args.max_workers) as ex:
+            futures = {ex.submit(check_external, ref): ref for ref in externals_to_check}
+            for fut in as_completed(futures):
+                ref = futures[fut]
+                err = fut.result()
+                if err:
+                    report.failures.append((ref, err))
 
     out = report_json(report) if args.json else report_text(report)
     print(out)


### PR DESCRIPTION
Closes #84.

## Summary

Adds a weekly GitHub Action that runs the existing `scripts/verify-links.py --live` and surfaces external link rot as a GitHub issue (not a deploy block).

## Changes

### Concurrency in verify-links.py
- `ThreadPoolExecutor(max_workers=8)` for external HEAD/GET checks
- New `--max-workers` CLI flag (default 8)
- Sequential at 72 URLs × 10s timeout was up to 12 min worst case; parallel collapses to ~90s
- Local checks stay sequential (already fast, no need)
- Added one new HOST_ALLOWLIST entry: testimonial author profile that LinkedIn 404s to bots

### Cron workflow
- `.github/workflows/verify-links-live.yml`
- cron `0 14 * * 1` (Mondays 9am CDT)
- `workflow_dispatch` for manual fires
- **Debounced issue filing**: if a `link-rot` issue is already open, comments on it instead of opening a new one — avoids issue-spam if a flaky host stays broken
- Always exits 0 (workflow status isn't the signal — the issue is)

The `link-rot` label is pre-created in the repo (yellow, FBCA04).

## Test plan

- [x] `python scripts/verify-links.py --live` passes locally with concurrency (113 local + 72 external + 18 skipped)
- [x] 70/70 self-test assertions pass
- [ ] Manual fire of the workflow once it lands to verify the cron mechanics

🤖 Generated with [Claude Code](https://claude.com/claude-code)