### PR TITLE
ci(substack): soft-fail fetch step to stop email noise from 403s

### DIFF
--- a/.github/workflows/substack-snapshot.yml
+++ b/.github/workflows/substack-snapshot.yml
@@ -34,6 +34,13 @@ jobs:
           python-version: '3.12'
 
       - name: Fetch + parse Substack feed
+        # Substack/Cloudflare intermittently 403s requests from GitHub-hosted
+        # runner egress IPs. A failed fetch leaves the existing snapshot in
+        # place; the commit step below will see no diff and exit cleanly.
+        # Soft-fail keeps scheduled runs green so we don't get email noise
+        # for an upstream block. Durable fix tracked separately (move fetch
+        # off Azure egress, e.g. Cloudflare Worker).
+        continue-on-error: true
         run: python scripts/snap-substack-feed.py
 
       - name: Commit snapshot if changed


### PR DESCRIPTION
## Summary
- Substack/Cloudflare has been returning HTTP 403 to the scheduled snapshot workflow every 4 hours from GitHub-hosted runner egress IPs, generating constant failed-workflow emails (8+ failures over the last 30 hours).
- Reproduction from a residential IP across multiple User-Agents (curl default, real Chrome, the script's existing UA) returns 200 every time — the block is **IP-based**, not UA-based, so a UA spoof alone wouldn't help.
- Add `continue-on-error: true` to the `Fetch + parse Substack feed` step so transient 403s no longer red the workflow run. The existing commit step already exits cleanly when there's no diff to `static/substack-latest.json`, so a failed fetch just means the snapshot stays at its last-good value.

## Why a soft-fail and not a real fix
This is the **stop-the-bleeding** fix to kill email noise immediately. The durable fix is to move the fetch off Azure egress — most likely a tiny Cloudflare Worker (free tier) or a Fly.io machine that we already pay for, then have the workflow pull the JSON from there instead of from Substack directly. That will be a follow-up PR/issue.

## Risk
- **Low.** Worst case: `static/substack-latest.json` becomes stale until either (a) Substack stops blocking the runner IP, or (b) the durable-fix PR lands. The hover popup keeps working off the last-good snapshot.
- No application code changes; workflow-only edit.

## Test plan
- [ ] CI green on this PR
- [ ] After merge, manually trigger `Substack snapshot` from the Actions tab and confirm the run is green even when fetch logs show `HTTP Error 403`
- [ ] Verify next scheduled run (within ~4 hours) does not produce a failure email

🤖 Generated with [Claude Code](https://claude.com/claude-code)