### PR TITLE
feat(substack): Cloudflare Worker proxy for IP-blocked feed fetch (closes #98)

### DIFF
--- a/.github/workflows/substack-snapshot.yml
+++ b/.github/workflows/substack-snapshot.yml
@@ -5,6 +5,9 @@ name: Substack snapshot
 # this file directly (no client-side CORS, no third-party tracking).
 #
 # See scripts/snap-substack-feed.py for the parser + output contract.
+# See infra/substack-proxy/README.md for the Cloudflare Worker proxy that
+# this workflow routes through (Substack/Cloudflare 403s GitHub runner IPs
+# directly; the SUBSTACK_FEED_URL repo Variable points at the proxy).
 
 on:
   schedule:
@@ -34,13 +37,13 @@ jobs:
           python-version: '3.12'
 
       - name: Fetch + parse Substack feed
-        # Substack/Cloudflare intermittently 403s requests from GitHub-hosted
-        # runner egress IPs. A failed fetch leaves the existing snapshot in
-        # place; the commit step below will see no diff and exit cleanly.
-        # Soft-fail keeps scheduled runs green so we don't get email noise
-        # for an upstream block. Durable fix tracked separately (move fetch
-        # off Azure egress, e.g. Cloudflare Worker).
-        continue-on-error: true
+        env:
+          # Repo Variable (Settings -> Secrets and variables -> Actions ->
+          # Variables). Set to the deployed Cloudflare Worker URL, e.g.
+          # https://substack-proxy.<account>.workers.dev/feed. If unset, the
+          # script falls back to the hardcoded Substack URL (which 403s from
+          # GitHub runner IPs but works locally).
+          SUBSTACK_FEED_URL: ${{ vars.SUBSTACK_FEED_URL }}
         run: python scripts/snap-substack-feed.py
 
       - name: Commit snapshot if changed

--- a/infra/substack-proxy/README.md
+++ b/infra/substack-proxy/README.md
@@ -1,0 +1,63 @@
+# Substack RSS Proxy (Cloudflare Worker)
+
+Stateless edge proxy that fetches `https://narendranathe.substack.com/feed`
+and returns the raw RSS XML. Exists because Substack/Cloudflare returns
+HTTP 403 to GitHub-hosted runner egress IPs, silently breaking the every-4h
+`substack-snapshot` workflow. See [issue #98](https://github.com/narendranathe/narendranathe.github.io/issues/98).
+
+The Worker:
+- Sends a real Chrome User-Agent + standard `Accept` / `Accept-Language` headers
+- Returns `Content-Type: application/rss+xml; charset=utf-8`
+- Caches for 15 minutes (`Cache-Control: public, max-age=900`)
+- Passes upstream non-200s through as real errors (no fake successes)
+
+Free-tier safe: 100k requests/day on Cloudflare Workers free plan; this
+endpoint is hit ~6 times/day by the cron, well under the limit.
+
+## Deploy
+
+One-time setup:
+
+```bash
+npm install -g wrangler
+wrangler login        # opens browser, authenticates against your Cloudflare account
+```
+
+Deploy from this directory:
+
+```bash
+cd infra/substack-proxy
+wrangler deploy
+```
+
+Wrangler will print the deployed URL, of the form:
+
+```
+https://substack-proxy.<account-subdomain>.workers.dev
+```
+
+## Wire into the snapshot workflow
+
+The Python script (`scripts/snap-substack-feed.py`) reads an env var
+`SUBSTACK_FEED_URL` and falls back to the hardcoded Substack URL when unset
+(so local runs from a residential IP keep working unchanged).
+
+The GitHub Actions workflow (`.github/workflows/substack-snapshot.yml`) reads
+the same env var from a **repository Variable** named `SUBSTACK_FEED_URL`.
+
+To wire it up after deploy:
+
+1. Go to the repo on GitHub: **Settings → Secrets and variables → Actions → Variables tab → New repository variable**
+2. Name: `SUBSTACK_FEED_URL`
+3. Value: `https://substack-proxy.<account-subdomain>.workers.dev/feed`
+4. Save. Next scheduled run (or a manual `workflow_dispatch`) will route through the Worker.
+
+## Verify
+
+Hit the deployed URL from your browser or curl. You should get RSS XML and a
+`200 OK`. If you get a JSON error body with a non-200 status, the upstream
+returned an error — the Worker surfaces it instead of silently swallowing it.
+
+```bash
+curl -i https://substack-proxy.<account-subdomain>.workers.dev/feed | head -20
+```

--- a/infra/substack-proxy/worker.ts
+++ b/infra/substack-proxy/worker.ts
@@ -1,0 +1,62 @@
+// Substack RSS proxy — Cloudflare Worker.
+//
+// Why this exists:
+// Substack/Cloudflare returns HTTP 403 to GitHub-hosted runner egress IPs,
+// which silently breaks the every-4h `substack-snapshot` workflow. Confirmed
+// IP-based block (same User-Agent from a residential IP returns 200), so a
+// stateless edge proxy in front of the feed is the durable fix.
+//
+// Behavior:
+// - Any path / method passes through; we always GET the upstream feed.
+// - Sends a real Chrome User-Agent + standard Accept / Accept-Language
+//   headers so Cloudflare's edge heuristics see a normal browser request.
+// - On 2xx upstream: stream the raw RSS XML back with a 15-minute public
+//   cache so repeated callers (workflow re-runs, debugging) hit cache.
+// - On non-2xx upstream: pass the status through with a small JSON error
+//   body so the calling workflow surfaces a real failure, not a fake 200.
+
+const UPSTREAM = "https://narendranathe.substack.com/feed";
+
+const BROWSER_HEADERS: HeadersInit = {
+  "User-Agent":
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 " +
+    "(KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
+  "Accept":
+    "text/html,application/xhtml+xml,application/xml;q=0.9," +
+    "image/avif,image/webp,*/*;q=0.8",
+  "Accept-Language": "en-US,en;q=0.9",
+};
+
+export default {
+  async fetch(_request: Request): Promise<Response> {
+    let upstream: Response;
+    try {
+      upstream = await fetch(UPSTREAM, {
+        method: "GET",
+        headers: BROWSER_HEADERS,
+        redirect: "follow",
+      });
+    } catch (err) {
+      return Response.json(
+        { error: "upstream_fetch_failed", detail: String(err) },
+        { status: 502 },
+      );
+    }
+
+    if (!upstream.ok) {
+      return Response.json(
+        { error: "upstream_non_200", status: upstream.status },
+        { status: upstream.status },
+      );
+    }
+
+    const body = await upstream.text();
+    return new Response(body, {
+      status: 200,
+      headers: {
+        "Content-Type": "application/rss+xml; charset=utf-8",
+        "Cache-Control": "public, max-age=900",
+      },
+    });
+  },
+};

--- a/infra/substack-proxy/wrangler.toml
+++ b/infra/substack-proxy/wrangler.toml
@@ -1,0 +1,3 @@
+name = "substack-proxy"
+main = "worker.ts"
+compatibility_date = "2026-01-01"

--- a/scripts/snap-substack-feed.py
+++ b/scripts/snap-substack-feed.py
@@ -36,6 +36,7 @@ import argparse
 import datetime as dt
 import html
 import json
+import os
 import re
 import sys
 import urllib.error
@@ -44,7 +45,12 @@ import xml.etree.ElementTree as ET
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
-DEFAULT_FEED = "https://narendranathe.substack.com/feed"
+# Allow an env-var override so CI can route through a Cloudflare Worker proxy
+# (see infra/substack-proxy/README.md). Substack/Cloudflare returns 403 to
+# GitHub-hosted runner egress IPs but accepts requests from a residential IP,
+# so local runs without the env var keep working against the canonical URL.
+_HARDCODED_FEED = "https://narendranathe.substack.com/feed"
+DEFAULT_FEED = os.environ.get("SUBSTACK_FEED_URL", "").strip() or _HARDCODED_FEED
 TARGET = REPO_ROOT / "static" / "substack-latest.json"
 TIMEOUT_S = 15
 USER_AGENT = "Mozilla/5.0 (compatible; PortfolioSubstackSnap/1.0)"


### PR DESCRIPTION
## Summary
Durable fix for the Substack snapshot 403 problem. Replaces PR #97's `continue-on-error` bandaid with an actual non-Azure egress path: a stateless Cloudflare Worker that proxies the RSS fetch.

Closes #98.

### Why
- Substack/Cloudflare returns HTTP 403 to GitHub-hosted runner egress IPs (confirmed: same UA from a residential IP returns 200, so the block is **IP-based**, not UA-based).
- PR #97 silenced the failure emails by adding `continue-on-error: true`, but the snapshot has been silently stale ever since.
- This PR routes the fetch through a Cloudflare Worker (free tier, ~62 lines of TS), restores the workflow's hard-fail behavior, and gets `static/substack-latest.json` updating again.

### What changed
- **`infra/substack-proxy/worker.ts`** — 62-line Cloudflare Worker. On any GET, fetches `https://narendranathe.substack.com/feed` with a real Chrome UA + standard `Accept`/`Accept-Language` headers. Returns `application/rss+xml; charset=utf-8` with `Cache-Control: public, max-age=900`. On upstream non-200, surfaces the same status with a JSON error body (no fake successes).
- **`infra/substack-proxy/wrangler.toml`** — minimal config (`name`, `main`, `compatibility_date`).
- **`infra/substack-proxy/README.md`** — deploy steps + how to set the `SUBSTACK_FEED_URL` repo Variable.
- **`scripts/snap-substack-feed.py`** — reads `SUBSTACK_FEED_URL` env var; empty/unset falls back to the hardcoded Substack URL (so local runs are unchanged). Treats empty string as unset (important: `${{ vars.X }}` produces `""` not absent when the GitHub Variable is missing).
- **`.github/workflows/substack-snapshot.yml`** — passes `SUBSTACK_FEED_URL: ${{ vars.SUBSTACK_FEED_URL }}` env on the fetch step. **Removes** PR #97's `continue-on-error: true` since hard-fail is correct again with the proxy in place.

## Order of operations (important)
1. **Merge** this PR.
2. **Deploy the Worker:** `cd infra/substack-proxy && wrangler deploy`. Note the resulting URL (e.g. `https://substack-proxy.<account>.workers.dev`).
3. **Set the repo Variable:** Settings → Secrets and variables → Actions → Variables → `New repository variable` → name `SUBSTACK_FEED_URL`, value the Worker URL.
4. **Trigger the workflow manually** from the Actions tab to confirm green.

If you merge the PR before steps 2-3, the workflow will hard-fail (no `continue-on-error` anymore) until the Variable is set. That's a feature — it's the correct signal that the proxy isn't wired up yet.

## Caveat
The Worker has no auth — it's a public proxy for a public RSS feed. Free tier (100k req/day) easily covers ~6 cron hits/day. If it ever gets abused, add a path check or shared-secret query param.

## Test plan
- [ ] CI green on this PR (workflow only fires on merge to main, so this just validates YAML parse)
- [ ] After Worker deploy + Variable set, manually trigger `Substack snapshot` → green
- [ ] `static/substack-latest.json` refreshes on next scheduled run

🤖 Generated with [Claude Code](https://claude.com/claude-code)