### PR TITLE
chore(resume): point download CTAs at Naren.E.pdf in resume2

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,7 +94,7 @@
         <a href="#signal"     class="nav-link">References</a>
         <a href="#connect"    class="nav-link">Contact</a>
       </nav>
-      <a href="/static/resume.pdf?v=7a55b6b6"
+      <a href="https://github.com/narendranathe/resume2/raw/master/Naren.E.pdf"
          class="btn btn-resume" target="_blank" rel="noreferrer"
          data-hover-preview="/static/resume-page1-preview.png?v=fc9a5e8c"
          data-hover-title="Resume - last updated Apr 30, 2026"
@@ -113,7 +113,7 @@
       <a href="#notes"      class="mobile-link">Publications</a>
       <a href="#signal"     class="mobile-link">References</a>
       <a href="#connect"    class="mobile-link">Contact</a>
-      <a href="/static/resume.pdf?v=7a55b6b6"
+      <a href="https://github.com/narendranathe/resume2/raw/master/Naren.E.pdf"
          class="mobile-link" target="_blank" rel="noreferrer"
          data-hover-preview="/static/resume-page1-preview.png?v=fc9a5e8c"
          data-hover-title="Resume - last updated Apr 30, 2026"
@@ -149,7 +149,7 @@
           </ul>
           <div class="hero-actions">
             <a href="#systems" class="btn btn-primary">View projects</a>
-            <a href="/static/resume.pdf?v=7a55b6b6"
+            <a href="https://github.com/narendranathe/resume2/raw/master/Naren.E.pdf"
                class="btn btn-ghost" target="_blank" rel="noreferrer"
                data-hover-preview="/static/resume-page1-preview.png?v=fc9a5e8c"
                data-hover-title="Resume - last updated Apr 30, 2026"
@@ -1274,7 +1274,7 @@
                data-hover-caption="AI infra notes, weekly cadence">
               <i class="fas fa-newspaper"></i><span>Follow my writing on Substack</span>
             </a>
-            <a href="/static/resume.pdf?v=7a55b6b6"
+            <a href="https://github.com/narendranathe/resume2/raw/master/Naren.E.pdf"
                target="_blank" rel="noreferrer" class="contact-link"
                data-hover-preview="/static/resume-page1-preview.png?v=fc9a5e8c"
                data-hover-title="Resume - last updated Apr 30, 2026"


### PR DESCRIPTION
## Summary

- Swaps all 4 resume `<a href>` occurrences in `index.html` from `/static/resume.pdf?v=7a55b6b6` to `https://github.com/narendranathe/resume2/raw/master/Naren.E.pdf` (109,255-byte PDF, pushed 2026-05-23)
- Interim move while PRD #100 / issue #101 ships the proper Pages-on-assets-repo migration. `snap-resume.py` will overwrite these on next run unless `PUBLIC_PATH` is updated or it's run with `--legacy-static-only` disabled
- Hover-preview PNG left untouched (still same-origin); only the download href changed

## Test plan

- [x] `curl -ILo /dev/null` against new URL: 200 OK, follows 302 to `raw.githubusercontent.com`, returns 109,255 bytes with `Content-Type: application/octet-stream`
- [x] PDF magic bytes confirmed (`%PDF-1.5` header, `%%EOF` terminator) - file is complete + openable
- [ ] After merge to `main`, GH Pages deploy completes (~2 min)
- [ ] Click each of the 4 resume CTAs on `https://narendranathe.github.io` (nav-resume, mobile-nav, hero-actions, footer); each triggers a `Naren.E.pdf` download
- [ ] Plausible `Resume Download` custom event still fires (now cross-origin, so the event source is the click handler, not the navigation - should still work)

## Branch note

Branch name `feat/hero-avif-webp-83` is leftover from the merged AVIF/WebP work (PR #94). This single-commit PR reuses the branch; it'll be deletable post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)