### PR TITLE
fix(portfolio): stop ML card overlapping the full-width SSIS_LoadPrep card

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -562,13 +562,12 @@ button { font-family: inherit; cursor: pointer; }
   margin-top: 1.5rem;
   align-items: start;
 }
-/* The ML Pipeline Projects card (DOM order #2) is genuinely tall because it
-   carries three sub-project entries plus an inline architecture SVG. Pin it
-   to the right column spanning both rows; the two shorter cards (Azure, then
-   repo-context-hooks) stack in the left column without inheriting the huge
-   row-height ML would otherwise impose on Azure. */
-.supporting-row > .support-card:nth-child(1) { grid-column: 1; grid-row: 1; }
-.supporting-row > .support-card:nth-child(2) { grid-column: 2; grid-row: 1 / span 2; }
+/* The SSIS_LoadPrep card (DOM order #1) carries two full architecture
+   diagrams, so it spans the whole row on top. The ML Pipeline Projects card
+   (#2) and the repo-context-hooks card (#3) then share the second row below
+   it, in their original right/left columns. */
+.supporting-row > .support-card:nth-child(1) { grid-column: 1 / -1; grid-row: 1; }
+.supporting-row > .support-card:nth-child(2) { grid-column: 2; grid-row: 2; }
 .supporting-row > .support-card:nth-child(3) { grid-column: 1; grid-row: 2; }
 .support-card {
   background: var(--bg); border: 1px solid var(--border);


### PR DESCRIPTION
## Problem

After #112 made the SSIS_LoadPrep card full-width (`grid-column: 1 / -1`), the card visually overlapped the **ML Pipeline Projects** card — the ML card rendered on top of the SSIS card's right half, clipping the heading and diagram.

### Root cause

`.supporting-row` hardcodes grid placement per child. The SSIS card (child 1) was made to span both columns **in row 1**, but the ML card (child 2) was still pinned to `grid-column: 2; grid-row: 1 / span 2`. Both then occupied cell (row 1, col 2) — a collision.

## Fix

`styles.css` only — move the ML and repo-context cards onto **row 2** so the full-width SSIS card owns row 1:

```css
.supporting-row > .support-card:nth-child(1) { grid-column: 1 / -1; grid-row: 1; }  /* SSIS, full width */
.supporting-row > .support-card:nth-child(2) { grid-column: 2; grid-row: 2; }        /* ML */
.supporting-row > .support-card:nth-child(3) { grid-column: 1; grid-row: 2; }        /* repo-context */
```

Resulting layout:

```
Row 1:  [ SSIS_LoadPrep — full width, both diagrams ]
Row 2:  [ repo-context-hooks ] [ ML Pipeline Projects ]
```

No grid cell is double-occupied. The mobile (≤900px) single-column stack is unchanged.

## Verification

Verified by a deterministic CSS-grid placement trace (every cell maps to exactly one card). **I was not able to produce a screenshot** — no browser is installed in the build environment and the headless-Chromium download is network-blocked — so a visual confirmation on the deployed Pages site (or local `python -m http.server`) is recommended after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QxjZ8KXSM5wqH2NBghG282)_