### PR TITLE
Fix dark-mode CSS leak washing out architecture diagrams

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1553,7 +1553,7 @@ body.splash-active { overflow: hidden; }
   .post-section code {
     background: #2a2522;
   }
-  .system-diagram { color: #f0f0f0; }
+  .post-body .system-diagram { color: #f0f0f0; }
   .post-figcaption,
   .post-meta,
   .post-footer { color: #b0a8a0; }


### PR DESCRIPTION
## Summary

- Fixes a bug where the inline architecture diagrams (Azure Platform Engineering, AutoApply AI, Portfolio Risk Analytics) rendered with near-invisible text for any visitor with OS/browser dark-mode preference on.

## Root cause

`styles.css` has a `@media (prefers-color-scheme: dark)` block written for a standalone "architecture post page" template (`.post-body`) that doesn't exist anywhere in this repo yet - `grep` confirms `.post-body` has zero usages in any `.html` file. That block's `.system-diagram { color: #f0f0f0; }` rule was unscoped, so it applied to the same-named diagrams on `index.html` too. `index.html` is a fixed light theme with no dark-mode background switch, so under `prefers-color-scheme: dark` the diagram text flipped to near-white (`#f0f0f0`) while the surrounding page background stayed light (`#fafaf8`) - text and background nearly the same color, exactly matching the "white space where there should be text" symptom.

## Fix

Scoped the rule to `.post-body .system-diagram` so it only applies once that template exists, leaving `index.html`'s diagrams untouched by it.

## Verification

Used a headless-browser script (Playwright) to render the page under both `light` and `dark` emulated `prefers-color-scheme` and read back each diagram's computed `color` and its container's computed `background-color`:

- **Before:** all three diagrams computed `color: rgb(240, 240, 240)` against a `rgb(250, 250, 248)` background under dark-mode emulation - confirmed reproduction of the bug.
- **After:** all three diagrams computed `color: rgb(26, 24, 24)` against `rgb(250, 250, 248)` under both light and dark emulation - fixed, no regression in light mode.

## Test plan

- [x] Reproduced the bug with a computed-style check under `prefers-color-scheme: dark` emulation
- [x] Verified the fix resolves it under dark-mode emulation
- [x] Verified no regression under light-mode emulation (screenshots compared, pixel-identical rendering)
- [x] Confirmed `.post-body` has no live usage in this repo today, so this change is a no-op until that template ships

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T71q1Lv25RNT1qwmbx9CTe

---
_Generated by [Claude Code](https://claude.ai/code/session_01T71q1Lv25RNT1qwmbx9CTe)_